### PR TITLE
Updated parent POM (one breaking change)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.settings
 /.project
+target

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.mybatis</groupId>
@@ -265,16 +265,16 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <javac.src.version>1.5</javac.src.version>
-    <javac.target.version>1.5</javac.target.version>
+    <maven.compiler.source>1.5</maven.compiler.source>
+    <maven.compiler.target>1.5</maven.compiler.target>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
     <clirr.comparisonVersion>${project.version}</clirr.comparisonVersion>
     <gcu.product>${project.name}</gcu.product>
     <!--
      | plugins configuration
     -->
-    <javadoc.version>2.9</javadoc.version>
-    <surefire.version>2.13</surefire.version>
+    <javadoc.version>2.9.1</javadoc.version>
+    <surefire.version>2.17</surefire.version>
     <findbugs.onlyAnalyze />
     <!--
      | OSGi configuration properties
@@ -289,6 +289,21 @@
   <build>
     <pluginManagement>
       <plugins>
+
+        <!-- Antrun here only to override eclipse settings -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.7</version>
+        </plugin>
+
+        <!-- Assembly here only to override eclipse settings -->
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.4</version>
+        </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
@@ -304,7 +319,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.8.1</version>
         </plugin>
 
         <plugin>
@@ -316,19 +331,19 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>2.4</version>
+          <version>2.5.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.5.2</version>
+          <version>2.6</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.3</version> <!-- 3.3 works wrong with fluido skin 1.3.x -->
+          <version>3.4</version> <!-- 3.3 works wrong with fluido skin 1.3.x -->
           <executions>
             <execution>
               <id>attach-descriptor</id>
@@ -343,18 +358,24 @@
               <artifactId>wagon-gitsite</artifactId>
               <version>0.4.1</version>
             </dependency>
+            <!-- Fluido here only for version update checks on site page -->
+            <dependency>
+              <groupId>org.apache.maven.skins</groupId>
+              <artifactId>maven-fluido-skin</artifactId>
+              <version>1.3.1</version>
+            </dependency>
           </dependencies>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.4.2</version>
+          <version>2.5</version>
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-provider-gitexe</artifactId>
-              <version>1.8.1</version>
+              <version>1.9</version>
             </dependency>
           </dependencies>
           <configuration>
@@ -385,7 +406,7 @@
         <plugin>
           <groupId>org.sonatype.plugins</groupId>
           <artifactId>jarjar-maven-plugin</artifactId>
-          <version>1.7</version>
+          <version>1.9</version>
           <!--
            | JarJar all classes before running tests
           -->
@@ -419,9 +440,8 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-idea-plugin</artifactId>
-          <version>2.2</version>
+          <version>2.2.1</version>
           <configuration>
-            <jdkLevel>${javac.src.version}</jdkLevel>
             <overwrite>true</overwrite>
             <downloadSources>true</downloadSources>
             <downloadJavadocs>true</downloadJavadocs>
@@ -437,6 +457,37 @@
             <downloadJavadocs>true</downloadJavadocs>
           </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>2.1</version>
+        </plugin>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+            <groupId>org.eclipse.m2e</groupId>
+            <artifactId>lifecycle-mapping</artifactId>
+            <version>1.0.0</version>
+            <configuration>
+                <lifecycleMappingMetadata>
+                    <pluginExecutions>
+                        <pluginExecution>
+                            <pluginExecutionFilter>
+                                <groupId>org.apache.felix</groupId>
+                                <artifactId>maven-bundle-plugin</artifactId>
+                                <versionRange>[2.4.0,)</versionRange>
+                                <goals>
+                                    <goal>manifest</goal>
+                                </goals>
+                            </pluginExecutionFilter>
+                            <action>
+                                <ignore></ignore>
+                            </action>
+                        </pluginExecution>
+                    </pluginExecutions>
+                </lifecycleMappingMetadata>
+            </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -444,7 +495,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3</version>
+        <version>1.3.1</version>
         <executions>
           <execution>
             <id>enforce-java</id>
@@ -458,7 +509,7 @@
                   <version>[1.5,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>[2.2.0,)</version>
+                  <version>[3.0.5,)</version>
                 </requireMavenVersion>
                 <requirePluginVersions>
                   <message>[ERROR] Best Practice is to always define plugin versions!</message>
@@ -479,7 +530,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.9</version>
+        <version>1.11</version>
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
@@ -501,7 +552,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.3.7</version>
+        <version>2.4.0</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>
@@ -542,7 +593,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
+        <version>2.5</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.directory}/osgi/MANIFEST.MF</manifestFile>
@@ -552,8 +603,8 @@
             </manifest>
             <manifestEntries>
               <Implementation-Build-Date>${maven.build.timestamp}</Implementation-Build-Date>
-              <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
-              <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
+              <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+              <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
             </manifestEntries>
           </archive>
         </configuration>
@@ -562,11 +613,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
         <configuration>
-          <source>${javac.src.version}</source>
-          <target>${javac.target.version}</target>
-          <encoding>${project.build.sourceEncoding}</encoding>
           <optimize>true</optimize>
         </configuration>
       </plugin>
@@ -585,7 +633,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.6.1</version>
         <configuration>
           <comparisonVersion>${clirr.comparisonVersion}</comparisonVersion>
           <failOnError>false</failOnError>
@@ -596,12 +644,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>
-        <version>1.8.1</version>
+        <version>1.9</version>
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.8.1</version>
+            <version>1.9</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -609,11 +657,11 @@
 
     <resources>
       <resource>
-        <directory>${basedir}/src/main/resources</directory>
+        <directory>${project.basedir}/src/main/resources</directory>
         <filtering>true</filtering>
       </resource>
       <resource>
-        <directory>${basedir}</directory>
+        <directory>${project.basedir}</directory>
         <targetPath>META-INF</targetPath>
         <includes>
           <include>LICENSE</include>
@@ -643,7 +691,7 @@
           <docletArtifact>
             <groupId>com.google.doclava</groupId>
             <artifactId>doclava</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.6</version>
           </docletArtifact>
           <additionalparam>
             -hdf project.name "${project.name}"
@@ -663,19 +711,19 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.4</version>
       </plugin>
 
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jdepend-maven-plugin</artifactId>
-        <version>2.0-beta-2</version>
+        <version>2.0</version>
       </plugin>
 
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5.2</version>
+        <version>2.5.3</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <xmlOutputDirectory>target/findbugs-reports</xmlOutputDirectory>
@@ -697,7 +745,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changes-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.9</version>
         <configuration>
           <issueLinkTemplate>%URL%/issues/%ISSUE%</issueLinkTemplate>
         </configuration>
@@ -713,11 +761,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>2.7.1</version>
+        <version>3.1</version>
         <configuration>
           <linkXref>true</linkXref>
           <minimumTokens>100</minimumTokens>
-          <targetJdk>${javac.target.version}</targetJdk>
         </configuration>
       </plugin>
 
@@ -749,10 +796,16 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.6.1</version>
         <configuration>
           <comparisonVersion>${clirr.comparisonVersion}</comparisonVersion>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.1</version>
       </plugin>
     </plugins>
   </reporting>
@@ -765,7 +818,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.1.2</version>
+            <version>2.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -780,8 +833,8 @@
                     </manifest>
                     <manifestEntries>
                       <Implementation-Build-Date>${maven.build.timestamp}</Implementation-Build-Date>
-                      <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
-                      <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
+                      <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                      <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
                     </manifestEntries>
                   </archive>
                 </configuration>
@@ -807,8 +860,8 @@
                     </manifest>
                     <manifestEntries>
                       <Implementation-Build-Date>${maven.build.timestamp}</Implementation-Build-Date>
-                      <X-Compile-Source-JDK>${javac.src.version}</X-Compile-Source-JDK>
-                      <X-Compile-Target-JDK>${javac.target.version}</X-Compile-Target-JDK>
+                      <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
+                      <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
                     </manifestEntries>
                   </archive>
                 </configuration>
@@ -819,7 +872,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
******\* BREAKING CHANGE *******
- Fixed source/target jdk to use maven defaults for same (ie these are
  jdk5 by default even though set directly).  This is a breaking change
  meaning that child poms overriding javac.src.version &
  javac.target.version will need changed to maven.compiler.source &
  maven.compiler.target.

If accepted, I will submit the fix for all the underlying poms as well.
******\* BREAKING CHANGE *********
- Updated plugin dependencies
- Added versions plugin for site page
- replaced deprecated 'basedir' with 'project.basedir'
- Change minimum maven required to 3.0.5
- Added a couple of items to override eclipse settings and thus show
  current on versions report
- Fixed xsd redirect to stop redirecting.
