### PR TITLE
Updated dependencies and scm fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,7 +274,7 @@
     <!--
      | plugins configuration
     -->
-    <javadoc.version>2.9.1</javadoc.version>
+    <javadoc.version>2.10.1</javadoc.version>
     <surefire.version>2.17</surefire.version>
     <findbugs.onlyAnalyze />
     <!--
@@ -308,13 +308,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>2.9</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.6</version>
         </plugin>
 
         <plugin>
@@ -326,7 +326,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>2.6</version>
+          <version>2.7</version>
         </plugin>
 
         <plugin>
@@ -385,14 +385,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.scm</groupId>
-              <artifactId>maven-scm-provider-gitexe</artifactId>
-              <version>1.9.2</version>
-            </dependency>
-          </dependencies>
+          <version>2.5.1</version>
           <configuration>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
@@ -628,7 +621,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.2</version>
         <configuration>
           <optimize>true</optimize>
         </configuration>
@@ -649,13 +642,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-plugin</artifactId>
         <version>1.9.2</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.9.2</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
       <plugin>
@@ -768,7 +754,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-changes-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.11</version>
         <configuration>
           <issueLinkTemplate>%URL%/issues/%ISSUE%</issueLinkTemplate>
         </configuration>
@@ -862,7 +848,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.3</version>
+            <version>2.4</version>
             <executions>
               <execution>
                 <id>attach-sources</id>


### PR DESCRIPTION
Updating maven plugin dependencies.
Removed dependency for scm pieces as not required on latest maven
versions as it is already pulled in.
