### PR TITLE
Added license plugin, updated enforcer plugin, and moved jarjar execution filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,30 @@
         </plugin>
 
         <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>2.9</version>
+          <configuration>
+            <header>${project.basedir}/license.txt</header>
+            <excludes>
+              <exclude>target/**</exclude>
+              <exclude>**/.gitignore</exclude>
+              <exclude>**/*.txt</exclude>
+              <exclude>**/*.xml</exclude>
+              <exclude>**/*.properties</exclude>
+              <exclude>**/*.html</exclude>
+              <exclude>**/*.css</exclude>
+            </excludes>
+            <includes>
+              <include>**/*.java</include>
+            </includes>
+            <mapping>
+              <java>JAVADOC_STYLE</java>
+            </mapping>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -931,6 +931,32 @@
     </profile>
 
     <profile>
+      <id>license</id>
+      <activation>
+        <file>
+          <!-- project.basedir is invalid in this locatino, use basedir -->
+          <exists>${basedir}/license.txt</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>compile</phase>
+                <goals>
+                  <goal>format</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>eclipse</id>
       <activation>
         <property>

--- a/pom.xml
+++ b/pom.xml
@@ -989,6 +989,19 @@
                     </pluginExecution>
                     <pluginExecution>
                       <pluginExecutionFilter>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>jarjar-maven-plugin</artifactId>
+                        <versionRange>[1.9,)</versionRange>
+                        <goals>
+                          <goal>jarjar</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore></ignore>
+                      </action>
+                    </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <versionRange>[0.7.2.201409121644,)</versionRange>

--- a/pom.xml
+++ b/pom.xml
@@ -454,7 +454,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
+        <version>1.4</version>
         <executions>
           <execution>
             <id>enforce-java</id>


### PR DESCRIPTION
License plugin provides easy way to update license headers.  Configured to run for java only and only when license.txt is present in root of project component being built.

Updated maven-enforcer-plugin to 1.4

Move jarjar execution filter from mybatis3 to parent and placed into profile with others.