### PR TITLE
Use sonatype parent, remove cobertura, use different site deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1036,6 +1036,19 @@
                         <ignore />
                       </action>
                     </pluginExecution>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>com.mycila</groupId>
+                        <artifactId>license-maven-plugin</artifactId>
+                        <versionRange>[2.11,)</versionRange>
+                        <goals>
+                          <goal>format</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore />
+                      </action>
+                    </pluginExecution>
                   </pluginExecutions>
                 </lifecycleMappingMetadata>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -278,14 +278,15 @@
   </distributionManagement>
 
   <properties>
+    <clirr.comparisonVersion>${project.version}</clirr.comparisonVersion>
+    <gcu.product>${project.name}</gcu.product>
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
-    <clirr.comparisonVersion>${project.version}</clirr.comparisonVersion>
-    <gcu.product>${project.name}</gcu.product>
+
     <!--
      | plugins configuration
     -->

--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>2.5.3</version>
+        <version>2.5.4</version>
         <executions>
           <execution>
             <id>bundle-manifest</id>

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
     <site>
       <id>gh-pages</id>
       <name>Mybatis GitHub Pages</name>
-      <url>git:ssh://git@github.com/mybatis/parent.git?gh-pages#</url>
+      <url>github:ssh://mybatis.github.io/parent/</url>
     </site>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.5.4</version>
+            <version>2.5.5</version>
         </plugin>
 
         <plugin>
@@ -418,7 +418,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.3</version>
+          <version>2.4</version>
         </plugin>
 
         <plugin>
@@ -465,7 +465,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.4.201502262128</version>
+          <version>0.7.5.201505241946</version>
         </plugin>
 
         <plugin>
@@ -814,7 +814,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.4.201502262128</version>
+        <version>0.7.5.201505241946</version>
       </plugin>
 
     </plugins>
@@ -907,7 +907,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
-            <version>2.5.4</version>
+            <version>2.5.5</version>
             <dependencies>
               <dependency>
                 <groupId>org.mybatis</groupId>
@@ -983,7 +983,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.felix</groupId>
                         <artifactId>maven-bundle-plugin</artifactId>
-                        <versionRange>[2.5.3,)</versionRange>
+                        <versionRange>[2.5.4,)</versionRange>
                         <goals>
                           <goal>manifest</goal>
                         </goals>
@@ -996,7 +996,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <versionRange>[0.7.4.201502262128,)</versionRange>
+                        <versionRange>[0.7.5.201505241946,)</versionRange>
                         <goals>
                           <goal>prepare-agent</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -465,14 +465,6 @@
           <version>${surefire.version}</version>
         </plugin>
 
-        <!-- Eventually remove this in favor of jacoco -->
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.7</version>
-        </plugin>
-
-        <!--  Introducing jacoco for sonarqube usage initially -->
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
@@ -815,18 +807,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>2.2</version>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>9</version>
+    <relativePath />
+  </parent>
+
   <groupId>org.mybatis</groupId>
   <artifactId>mybatis-parent</artifactId>
   <version>25-SNAPSHOT</version>
@@ -235,20 +242,6 @@
     </mailingList>
   </mailingLists>
 
-  <repositories>
-    <repository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
   <scm>
     <url>http://github.com/mybatis/parent</url>
     <connection>scm:git:ssh://github.com/mybatis/parent.git</connection>
@@ -264,17 +257,6 @@
     <url>https://travis-ci.org/mybatis/parent</url>
   </ciManagement>
   <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
     <site>
       <id>gh-pages</id>
       <name>Mybatis GitHub Pages</name>
@@ -475,16 +457,6 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.2</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-maven-plugin</artifactId>
-          <version>2.1</version>
-          <configuration>
-            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <serverAuthId>sonatype-nexus-staging</serverAuthId>
-          </configuration>
         </plugin>
 
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,11 @@
       <name>Nexus Release Repository</name>
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
+    <site>
+      <id>gh-pages</id>
+      <name>Mybatis GitHub Pages</name>
+      <url>git:ssh://git@github.com/mybatis/parent.git?gh-pages#</url>
+    </site>
   </distributionManagement>
 
   <properties>
@@ -436,15 +441,20 @@
           </executions>
           <dependencies>
             <dependency>
-              <groupId>com.github.stephenc.wagon</groupId>
-              <artifactId>wagon-gitsite</artifactId>
-              <version>0.4.1</version> <!-- version 0.5 fails on linux -->
+              <groupId>net.trajano.wagon</groupId>
+              <artifactId>wagon-git</artifactId>
+              <version>2.0.3</version>
             </dependency>
             <!-- Fluido here only for version update checks on site page -->
             <dependency>
               <groupId>org.apache.maven.skins</groupId>
               <artifactId>maven-fluido-skin</artifactId>
               <version>1.4</version>
+            </dependency>
+            <dependency>
+              <groupId>org.apache.maven.wagon</groupId>
+              <artifactId>wagon-ssh</artifactId>
+              <version>2.9</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -658,6 +668,13 @@
         </includes>
       </resource>
     </resources>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh</artifactId>
+        <version>2.9</version>
+      </extension>
+    </extensions>
   </build>
 
   <reporting>


### PR DESCRIPTION
Before merging this in, this needs a slight discussion.  With cobertura being removed and site deploy changing, its important every mybatis module get the updates all at once.  Initially, I'm putting up the parent and mybatis-3.  Once these are approved as go forwards, I'll go through remainder and start merging them all at once.

Check out usage of 'mvn site:deploy' as done to the following to verify this is what is needed.

http://hazendaz.github.io/parent/
http://hazendaz.github.io/mybatis-3/

The above are on my fork.  The real PR will be targetted for mybatis gh-pages.

The steps to perform this are pretty simple.

'mvn site' will continue to build the site out and should be run before a deploy.  This is local only.
'mvn site:deploy' will deploy out to mybatis gh site pages.

In .m2/settings.xml, this is required in order to pull this off.  There are other options so see the main website for the new plugin.  In this case below it assumes ssh usage which is exactly how i've setup the parent & mybatis-3.
    <server>
      <id>gh-pages</id>
      <password>SOME_SSH_PASSWORD_HERE</password>
    </server>

Plugin site is here for learning how this works.

https://github.com/trajano/wagon-git

Now the good stuff.  Last full mybatis site was released it sounded like that took many hours to accomplish.  With this method, it took 6 minutes 43 seconds.  Timings may very but this is significantly faster and required me to do nothing more than issue the commands I mentioned in a git shell.

Now for cobertura.  Removal of this in parent pretty much means we need to do this across the board at once.  Not doing so runs into maven warnings and build issues becuase of configurations without versions and skipped steps.  So it is best to just get this out all at once.

As soon as both the parent and mybatis-3 are verified, I'll spin through all the same day and merge them on my own.  Until then, please just review.