### PR TITLE
Replace OSS Parent and update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MyBatis Parent
 ==============
 
+[![Build Status](https://travis-ci.org/mybatis/parent.svg?branch=master)](https://travis-ci.org/mybatis/parent)
+[![Dependency Status](https://www.versioneye.com/user/projects/55ff649c601dd9001f0001b5/badge.svg?style=flat)](https://www.versioneye.com/user/projects/55ff649c601dd9001f0001b5)
 [![Maven central](https://maven-badges.herokuapp.com/maven-central/org.mybatis/mybatis-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.mybatis/mybatis-parent)
 
 ![mybatis-parent](http://mybatis.github.io/images/mybatis-logo.png)

--- a/pom.xml
+++ b/pom.xml
@@ -467,7 +467,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4</version>
+        <version>1.4.1</version>
         <executions>
           <execution>
             <id>enforce-java</id>

--- a/pom.xml
+++ b/pom.xml
@@ -647,7 +647,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.8</version>
+        <version>2.8.1</version>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -732,7 +732,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.5</version>
         <configuration>
           <linkXref>true</linkXref>
           <minimumTokens>100</minimumTokens>

--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
             <dependency>
               <groupId>org.apache.maven.wagon</groupId>
               <artifactId>wagon-ssh</artifactId>
-              <version>2.9</version>
+              <version>2.10</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -637,7 +637,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-ssh</artifactId>
-        <version>2.9</version>
+        <version>2.10</version>
       </extension>
     </extensions>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4</version>
+          <version>2.4.1</version>
         </plugin>
 
         <plugin>
@@ -980,7 +980,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <versionRange>[1.4,)</versionRange>
+                        <versionRange>[1.4.1,)</versionRange>
                         <goals>
                           <goal>enforce</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -426,7 +426,7 @@
             <dependency>
               <groupId>net.trajano.wagon</groupId>
               <artifactId>wagon-git</artifactId>
-              <version>2.0.3</version>
+              <version>2.0.3</version> <!-- 2.0.4 has jgit errors -->
             </dependency>
             <!-- Fluido here only for version update checks on site page -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -694,7 +694,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.0.2</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <xmlOutputDirectory>${project.build.directory}/target/findbugs-reports</xmlOutputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>9</version>
-    <relativePath />
-  </parent>
-
   <groupId>org.mybatis</groupId>
   <artifactId>mybatis-parent</artifactId>
   <version>26-SNAPSHOT</version>
@@ -262,6 +255,14 @@
       <name>Mybatis GitHub Pages</name>
       <url>github:ssh://mybatis.github.io/parent/</url>
     </site>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
   </distributionManagement>
 
   <properties>


### PR DESCRIPTION
sonatype oss-parent is deprecated.  This is noted on sonatype site.  Mybatis already followed release separately before this was introduced so this shouldn't be that bad.  The distribution elements are now directly added.