### PR TITLE
Exclude classes/methods/fields annotated with UsesJava7 or UsesJava8 …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -536,6 +536,10 @@
             <artifactId>${signature.artifact}</artifactId>
             <version>${signature.version}</version>
           </signature>
+          <annotations>
+            <annotation>org.apache.ibatis.lang.UsesJava7</annotation>
+            <annotation>org.apache.ibatis.lang.UsesJava8</annotation>
+          </annotations>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
…from the animal-sniffer's signature check.