### PR TITLE
[jdk8 usage] Adjust for jdk8 usage on test cases and remove test/source compiler mixup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,8 +267,8 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ssZ</maven.build.timestamp.format>
     <maven.compiler.source>1.6</maven.compiler.source>
     <maven.compiler.target>1.6</maven.compiler.target>
-    <maven.compiler.testTarget>1.6</maven.compiler.testTarget>
-    <maven.compiler.testSource>1.6</maven.compiler.testSource>
+    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+    <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -1082,14 +1082,6 @@
                     </pluginExecution>
                   </pluginExecutions>
                 </lifecycleMappingMetadata>
-              </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <source>${maven.compiler.testSource}</source>
-                <target>${maven.compiler.testTarget}</target>
               </configuration>
             </plugin>
           </plugins>


### PR DESCRIPTION
@harawata Can you review this and verify this is what you expect for jdk8 usage on test cases?  I don't see any real reason to not make this happen against all projects.  Eclipse might be a slight problem but it's easily worked around.