### PR TITLE
Update clirr-maven-plugin to 2.8 for support Java 8 byte code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -618,7 +618,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.8</version>
         <configuration>
           <comparisonVersion>${clirr.comparisonVersion}</comparisonVersion>
           <failOnError>false</failOnError>
@@ -785,7 +785,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>clirr-maven-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.8</version>
         <configuration>
           <comparisonVersion>${clirr.comparisonVersion}</comparisonVersion>
         </configuration>


### PR DESCRIPTION
Currently, maven site is fail on mybatis project as follows:

```
$ mvn site
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.5.1:site (default-site) on project mybatis: Execution default-site of goal org.apache.maven.plugins:maven-site-plugin:3.5.1:site failed: Invalid byte tag in constant pool: 18 -> [Help 1]
...
```
