### PR TITLE
Jacoco report goal is incorrectly configured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -642,12 +642,6 @@
               <goal>prepare-agent</goal>
             </goals>
           </execution>
-          <execution>
-            <id>report</id>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
"report" is a reporting goal, not a build goal.  If necessary,
configurations to "report" should be made under the reporting section of
the pom.  There's no need to add it in under reporting in the parent
because it is executed automatically by the site goal.

Having the goal configured here causes maven to build the jacoco site
during the build which can cause problems for downstream projects that
might want to change how the jacoco site is built.