### PR TITLE
[pom] Update build-tools to 1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
             <dependency>
               <groupId>com.github.hazendaz</groupId>
               <artifactId>build-tools</artifactId>
-              <version>1.1.2</version>
+              <version>1.1.3</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
- holds eclipse formatting rules for use with eclipse formatter plugin - 