### PR TITLE
Update dependencies and fix jacoco reporting aggregation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,7 +506,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>7.7</version>
+            <version>7.8</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -833,7 +833,7 @@
             </reports>
           </reportSet>
         </reportSets>
-    </plugin>
+      </plugin>
 
     </plugins>
   </reporting>
@@ -865,6 +865,7 @@
         </plugins>
       </build>
     </profile>
+
     <profile>
       <id>release</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -825,7 +825,15 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.7.9</version>
-      </plugin>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <!-- select non-aggregate reports -->
+              <report>report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+    </plugin>
 
     </plugins>
   </reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -528,7 +528,7 @@
                   <version>[1.6,)</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>[3.0.5,)</version>
+                  <version>[3.2.5,)</version>
                 </requireMavenVersion>
                 <requirePluginVersions>
                   <message>[ERROR] Best Practice is to always define plugin versions!</message>


### PR DESCRIPTION
It's time for maven 3.2.5 given...

3.2.5 - java 6
3.3.x - java 7
3.5.0 - java 7

So three levels in line with support from other platforms like travis ci.