### PR TITLE
[pom] Update build-tools to 1.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
             <dependency>
               <groupId>com.github.hazendaz</groupId>
               <artifactId>build-tools</artifactId>
-              <version>1.1.3</version>
+              <version>1.1.4</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
This cut includes a 4 space variation of the 2 space used by mybatis.  More specifically this one is for the generator that uses 4 spaces but currently does not have this live turned on due to level of changes.