### PR TITLE
[pom] Correct findbugs configuration - fixes #88

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -727,8 +727,8 @@
         <version>3.0.4</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
-          <xmlOutputDirectory>${project.build.directory}/target/findbugs-reports</xmlOutputDirectory>
-          <findbugsXmlOutput>${project.build.directory}/target/findbugs-reports</findbugsXmlOutput>
+          <xmlOutputDirectory>${project.build.directory}/findbugs-reports</xmlOutputDirectory>
+          <findbugsXmlOutputDirectory>${project.build.directory}/findbugs-reports</findbugsXmlOutputDirectory>
           <threshold>High</threshold>
           <effort>Max</effort>
           <visitors>FindDeadLocalStores,UnreadFields</visitors>


### PR DESCRIPTION
Fixes #88 

Not only was the wrong thing used, it never showed up as a problem as it was deprecated long ago and isn't even used internally.  Beyond that, for a long time I had noticed we had some find bug files in the target directory.  As it turns out our normal confirmation was wrong and we were missing the actual intended setting for findbugsXmlOutputDirectory.  So now this works properly.