### PR TITLE
[pom] Use spotbugs-maven-pugin 3.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -724,7 +724,7 @@
       <plugin>
         <groupId>com.github.hazendaz.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.0.5-SNAPSHOT</version>
+        <version>3.0.6</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <xmlOutputDirectory>${project.build.directory}/findbugs-reports</xmlOutputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -722,9 +722,9 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.4</version>
+        <groupId>com.github.hazendaz.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>3.0.5-SNAPSHOT</version>
         <configuration>
           <xmlOutput>true</xmlOutput>
           <xmlOutputDirectory>${project.build.directory}/findbugs-reports</xmlOutputDirectory>


### PR DESCRIPTION
Findbugs has become defunct.  As a result, a new drop in place project called spotbugs is taking it's place.  As such the existing maven plugin for findbugs easily converts to use findbugs with little work.  While I'm trying to get traction on getting the original findbugs maven plugin updated, this introduction here will serve for early testing and maybe even final use if no traction is made.  As any underlying projects switch to this parent that define findbugs, the group/artifact will need to chage but all else will work the same.

Update: Checkstyle project is going to start using spotbugs-maven-plugin as well as others.  Testing flushed out an issue in upgrades I did so now version 3.0.6 is current with fixes.  Therefore this will no longer serve as testing area since that project is much larger and has already proved this model is working.