### PR TITLE
Upgrade enforcer plugin version to 3.0.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
+        <version>3.0.0-M1</version>
         <executions>
           <execution>
             <id>enforce-java</id>


### PR DESCRIPTION
The current version fails when running on JDK 9. Enforcer plugin version
3.0.0-M1 runs fine in JDK 9.