### PR TITLE
Add junit-vintage-engine on maven-surefire-plugin for supporting JUnit 4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,11 @@
               <artifactId>junit-jupiter-engine</artifactId>
               <version>${junit-engine.version}</version>
             </dependency>
+            <dependency>
+              <groupId>org.junit.vintage</groupId>
+              <artifactId>junit-vintage-engine</artifactId>
+              <version>${junit-engine.version}</version>
+            </dependency>
           </dependencies>
         </plugin>
 


### PR DESCRIPTION
I will propose to add the `junit-vintage-engine` on `maven-surefire-plugin` 's dependency because many MyBatis modules depends on JUnit 4 yet.
It need to perform test case class created by JUnit 4 on JUnit platform. 