### PR TITLE
Make build work with jdk 10 and use autodetection of surefire provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
     <site.version>3.7</site.version>
     <source.version>3.0.1</source.version>
     <spotbugs.version>3.1.3</spotbugs.version>
-    <surefire.version>2.19.1</surefire.version> <!-- TODO: 2.22.0 is supposed to support junit 5 so we need to stay on 2.19.1 for now -->
+    <surefire.version>2.22.0</surefire.version>
     <taglist.version>2.4</taglist.version>
     <versions.version>2.5</versions.version>
     <wagon-git.version>2.0.3</wagon-git.version> <!-- Do not upgrade to 2.0.4 as it does not work with ssh properly -->
@@ -526,18 +526,6 @@
             <!-- In case of jmockit usage with jdk9 -->
             <argLine>-Djdk.attach.allowAttachSelf</argLine>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.junit.platform</groupId>
-              <artifactId>junit-platform-surefire-provider</artifactId>
-              <version>${junit-platform.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.junit.jupiter</groupId>
-              <artifactId>junit-jupiter-engine</artifactId>
-              <version>${junit-engine.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This allows proper detection of junit (so we don't skip junit 4 tests for example) and allows the project to build correctly using jdk 10