### PR TITLE
Fix JaCoCo Integration with Surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,7 +524,7 @@
           <version>${surefire.version}</version>
           <configuration>
             <!-- In case of jmockit usage with jdk9 -->
-            <argLine>-Djdk.attach.allowAttachSelf</argLine>
+            <argLine>${argLine} -Djdk.attach.allowAttachSelf</argLine>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
If you specify an argument for Surefire, then you must also include the
${argLine} property from JaCoCo.