### PR TITLE
Introduction of modernizer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,7 @@
           <artifactId>modernizer-maven-plugin</artifactId>
           <version>${modernizer.plugin}</version>
           <configuration>
+            <failOnViolations>false</failOnViolations>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -319,6 +319,7 @@
     <jxr.version>3.0.0</jxr.version>
     <license.version>3.0</license.version>
     <lifecycle.version>1.0.0</lifecycle.version>
+    <modernizer.plugin>1.7.1</modernizer.plugin>
     <pdf.version>1.4</pdf.version>
     <pmd.version>3.11.0</pmd.version>
     <project-info.version>3.0.0</project-info.version>
@@ -560,6 +561,15 @@
           </dependencies>
         </plugin>
 
+        <plugin>
+          <groupId>org.gaul</groupId>
+          <artifactId>modernizer-maven-plugin</artifactId>
+          <version>${modernizer.plugin}</version>
+          <configuration>
+            <javaVersion>${maven.compiler.target}</javaVersion>
+          </configuration>
+        </plugin>
+
       </plugins>
     </pluginManagement>
 
@@ -731,6 +741,20 @@
             <id>prepare-agent</id>
             <goals>
               <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>modernizer</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
This assists with ensuring we use more modern java usage throughout.  I have downgraded this to simply throw errors but not prevent builds as it will take some time to verify no issues throughout code bases.  There is exactly one item in mybatis-core that needs a patch due to this so it ignores the checks and I suspect there might be some in other modules.  For now though this is a welcome addition I've been otherwise using elsewhere most of 2018 to great success.