### PR TITLE
Update to jacoco 0.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
     <formatter.version>2.10.0</formatter.version>
     <gpg.version>1.6</gpg.version>
     <install.version>3.0.0-M1</install.version>
-    <jacoco.version>0.8.4</jacoco.version>
+    <jacoco.version>0.8.5</jacoco.version>
     <jar.version>3.1.2</jar.version>
     <javadoc.version>3.1.1</javadoc.version>
     <jxr.version>3.0.0</jxr.version>


### PR DESCRIPTION
The jacoco 0.8.5 is first version that support JDK 13 officially and support JDK 14 experimentally. 

For details, see https://github.com/jacoco/jacoco/releases/tag/v0.8.5.  