### PR TITLE
Raise up jdk9on javadocType setting, junit 5 travis only run, and add support for pom sorting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,9 @@
     <signature.group>org.codehaus.mojo.signature</signature.group>
     <signature.artifact>java18</signature.artifact>
     <signature.version>1.0</signature.version>
+
+    <!-- Add slow test groups here and annotate classes similar to @Tag('groupName') which will auto enable on travis-ci only. -->
+    <excludedGroups />
   </properties>
 
   <build>
@@ -1078,6 +1081,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <!-- Run slow tests only on travis ci, to force run otherwise use -D"env.TRAVIS" -->
+      <id>travis-ci</id>
+      <activation>
+        <property>
+          <name>env.TRAVIS</name>
+        </property>
+      </activation>
+      <properties>
+        <excludedGroups />
+      </properties>
     </profile>
 
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@
     <clirr.comparisonVersion>31</clirr.comparisonVersion>
     <formatter.config>eclipse-formatter-config-2space.xml</formatter.config>
     <gcu.product>${project.name}</gcu.product>
+    <html.javadocType>-html5</html.javadocType>
     <maven.min-version>3.2.5</maven.min-version>
     <module.name>org.mybatis.parent</module.name>
     <spotbugs.onlyAnalyze />
@@ -979,6 +980,26 @@
             </executions>
           </plugin>
         </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>jdk9on</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <configuration>
+                <additionalOptions>${html.javadocType}</additionalOptions>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1135,6 +1135,27 @@
     </profile>
 
     <profile>
+      <id>sort</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>tidy-maven-plugin</artifactId>
+            <version>1.0.0</version>
+            <executions>
+              <execution>
+                <phase>verify</phase>
+                <goals>
+                  <goal>pom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <id>license</id>
       <activation>
         <file>


### PR DESCRIPTION
The javadoctype setting can be adjusted as needed by overriding property.  It's set to -html5 which is generally going to be acceptable but yet to be tested across all of mybatis.  If issue is encountered, simply se that to -html4 or remove it.  Given this is for jdk 9 and above it's scope is currently limited.

mybatis had some slow running tests.  During junit 5 migrations, it was enhanced to run some tests on travis only. Bring that logic up so all of mybatis can benefit from that.

Add in profile to allow for easy way to manually sort the poms to comply with maven layout.