### PR TITLE
[pom] Bump build-tools to 1.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
     -->
     <asm.version>8.0.1</asm.version>
     <base-bundle.version>9</base-bundle.version>
-    <build-tools.version>1.2.3</build-tools.version>
+    <build-tools.version>1.2.4</build-tools.version>
     <checkstyle-core.version>8.32</checkstyle-core.version>
     <fluido.version>1.9</fluido.version>
     <wagon-git.version>2.0.3</wagon-git.version> <!-- Do not upgrade to 2.0.4 as it does not work with ssh properly -->


### PR DESCRIPTION
bug in 1.2.3 caused checkstyle to fail run.  This corrects the issue.