### PR TITLE
[pom] Override bundle dependency plugin to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,7 @@
     -->
     <asm.version>8.0.1</asm.version>
     <base-bundle.version>9</base-bundle.version>
+    <bnd.version>5.1.0</bnd.version>
     <build-tools.version>1.2.4</build-tools.version>
     <checkstyle-core.version>8.33</checkstyle-core.version>
     <fluido.version>1.9</fluido.version>
@@ -693,6 +694,13 @@
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <version>${bundle.version}</version>
+        <dependencies>
+            <dependency>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>biz.aQute.bndlib</artifactId>
+                <version>${bnd.version}</version>
+            </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>bundle-manifest</id>


### PR DESCRIPTION
partial fix for jdk 15 support.  Still need jacoco at minimum for the core of mybatis.