### PR TITLE
[pom] Resolve git.commit.id issue with bundle plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -520,6 +520,7 @@
               <Import-Package>${osgi.import}</Import-Package>
               <DynamicImport-Package>${osgi.dynamicImport}</DynamicImport-Package>
               <Bundle-DocURL>${project.url}</Bundle-DocURL>
+              <Git-Revision>${git.commit.id}</Git-Revision>
             </instructions>
           </configuration>
           <dependencies>
@@ -655,7 +656,6 @@
               <manifestEntries>
                 <Automatic-Module-Name>${module.name}</Automatic-Module-Name>
                 <Copyright>${copyright}</Copyright>
-                <Git-Revision>${git.commit.id}</Git-Revision>
                 <X-Compile-Source-JDK>${maven.compiler.source}</X-Compile-Source-JDK>
                 <X-Compile-Target-JDK>${maven.compiler.target}</X-Compile-Target-JDK>
                 <X-Compile-Release-JDK>${maven.compiler.release}</X-Compile-Release-JDK>


### PR DESCRIPTION
Move git.commit.id to instructions as it fails to pick up properly otherwise.  Removed from jar.  Javadoc and Source are ok.