### PR TITLE
Remove optimize and add parameters to compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -580,6 +580,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${compiler.plugin}</version>
           <configuration>
+            <parameters>true</parameters>
             <!-- Slightly faster builds, see https://issues.apache.org/jira/browse/MCOMPILER-209 -->
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -580,7 +580,6 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${compiler.plugin}</version>
           <configuration>
-            <optimize>true</optimize>
             <!-- Slightly faster builds, see https://issues.apache.org/jira/browse/MCOMPILER-209 -->
             <useIncrementalCompilation>false</useIncrementalCompilation>
           </configuration>


### PR DESCRIPTION
optimize is deprecated and no longer does anything with javac.  add parameters to provide usable data for reflection.