### PR TITLE
[pom] Lock down version range in more concise way

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [11, 17, 18, 19-ea]
+        java: [11, 17, 19, 20-ea]
         distribution: ['zulu']
       fail-fast: false
       max-parallel: 4

--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
     <copyright>2022</copyright>
 
     <!-- General configuration -->
-    <allowed.build.jdks>11,17,18,19,20</allowed.build.jdks>
+    <allowed.build.jdks>[11,12),[17,18),[19,20),[20,21)</allowed.build.jdks>
     <checkstyle.config>checkstyle.xml</checkstyle.config>
     <clirr.comparisonVersion>34</clirr.comparisonVersion>
     <formatter.config>eclipse-formatter-config-2space.xml</formatter.config>


### PR DESCRIPTION
Previously, this only enforced jdk 11 or above.  The other values didn't really do anything other than indicate our intended support levels.  New setup will force any 11, any 17, any 19, or any 20 and block all others.

Fixes #401 