### PR TITLE
Add site GHA and migrate maven bundle plugin to bnd-maven-plugin

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -1,0 +1,34 @@
+name: Site
+
+on:
+  push:
+    branches:
+      - site
+
+jobs:
+  build:
+    if: github.repository_owner == 'mybatis' && ! contains(toJSON(github.event.head_commit.message), '[maven-release-plugin]')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 21
+          distribution: zulu
+      - uses: webfactory/ssh-agent@master
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_KEY }}
+      - name: Build site
+        run: ./mvnw site site:stage -DskipTests -B -V --no-transfer-progress -Dlicense.skip=true
+        env:
+          CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy Site to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        with:
+          ssh-key: true
+          branch: gh-pages
+          folder: target/staging
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,7 @@
     <!-- Dependency versions -->
     <asm.version>9.6</asm.version>
     <base-bundle.version>11</base-bundle.version>
+    <bnd.version>7.0.0</bnd.version>
     <build-tools.version>1.3.1</build-tools.version>
     <checkstyle.version>10.12.5</checkstyle.version>
     <extra-enforcer-rules.version>1.7.0</extra-enforcer-rules.version>
@@ -533,6 +534,13 @@
               Import-Package: ${osgi.import}
             ]]></bnd>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>biz.aQute.bnd</groupId>
+              <artifactId>biz.aQute.bndlib</artifactId>
+              <version>${bnd.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
 
         <!-- Antrun here only to override eclipse settings -->
@@ -1385,7 +1393,8 @@
         <jdk>(,17)</jdk>
       </activation>
       <properties>
-        <bnd.plugin>6.4.1</bnd.plugin>
+        <bnd.plugin>6.4.0</bnd.plugin>
+        <bnd.version>6.4.1</bnd.version>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -312,7 +312,6 @@
     <!-- Dependency versions -->
     <asm.version>9.6</asm.version>
     <base-bundle.version>11</base-bundle.version>
-    <bnd.version>6.4.1</bnd.version>
     <build-tools.version>1.3.1</build-tools.version>
     <checkstyle.version>10.12.5</checkstyle.version>
     <extra-enforcer-rules.version>1.7.0</extra-enforcer-rules.version>
@@ -322,7 +321,7 @@
     <!-- Plugins versions -->
     <antrun.plugin>3.1.0</antrun.plugin>
     <assembly.plugin>3.6.0</assembly.plugin>
-    <bundle.plugin>5.1.9</bundle.plugin>
+    <bnd.plugin>7.0.0</bnd.plugin>
     <checkstyle.plugin>3.3.1</checkstyle.plugin>
     <clean.plugin>3.3.2</clean.plugin>
     <clirr.plugin>2.8</clirr.plugin>
@@ -514,39 +513,26 @@
         </plugin>
 
         <plugin>
-          <groupId>org.apache.felix</groupId>
-          <artifactId>maven-bundle-plugin</artifactId>
-          <version>${bundle.plugin}</version>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <version>${bnd.plugin}</version>
           <configuration>
-            <excludeDependencies>true</excludeDependencies>
-            <manifestLocation>${project.build.directory}/osgi</manifestLocation>
-            <supportedProjectTypes>
-              <supportedProjectType>jar</supportedProjectType>
-              <supportedProjectType>bundle</supportedProjectType>
-              <supportedProjectType>war</supportedProjectType>
-              <supportedProjectType>maven-plugin</supportedProjectType>
-            </supportedProjectTypes>
-            <instructions>
-              <!-- stops the "uses" clauses being added to "Export-Package" manifest entry -->
-              <_nouses>true</_nouses>
-              <!-- Stop the JAVA_1_n_HOME / JAVA_n_HOME variables from being treated as headers by Bnd if found in settings.xml (obsolete versions removed, if found, cleanup settings.xml) -->
-              <_removeheaders>JAVA_1_8_HOME,JAVA_8_HOME,JAVA_11_HOME,JAVA_17_HOME,JAVA_21_HOME,JAVA_22_HOME</_removeheaders>
-              <Bundle-SymbolicName>${osgi.symbolicName}</Bundle-SymbolicName>
-              <Export-Package>${osgi.export}</Export-Package>
-              <Private-Package>${osgi.private}</Private-Package>
-              <Import-Package>${osgi.import}</Import-Package>
-              <DynamicImport-Package>${osgi.dynamicImport}</DynamicImport-Package>
-              <Bundle-DocURL>${project.url}</Bundle-DocURL>
-              <Git-Revision>${git.commit.id}</Git-Revision>
-            </instructions>
+            <manifestPath>${project.build.directory}/osgi/MANIFEST.MF</manifestPath>
+            <packagingTypes>jar,bundle,maven-plugin,war</packagingTypes>
+            <bnd><![CDATA[
+              // 'nouses' stops the "uses" clauses being added to "Export-Package" manifest entry
+              -nouses: true
+              // 'removeheaders' Stop the JAVA_1_n_HOME / JAVA_n_HOME variables from being treated as headers by Bnd if found in settings.xml (obsolete versions removed, if found, cleanup settings.xml)
+              -removeheaders: JAVA_1_8_HOME,JAVA_8_HOME,JAVA_11_HOME,JAVA_17_HOME,JAVA_21_HOME,JAVA_22_HOME
+              Bundle-Developers:
+              Bundle-DocURL: ${project.url}
+              Bundle-SymbolicName: ${osgi.symbolicName}
+              DynamicImport-Package: ${osgi.dynamicImport}
+              Export-Package: ${osgi.export}
+              Private-Package: ${osgi.private}
+              Import-Package: ${osgi.import}
+            ]]></bnd>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>biz.aQute.bnd</groupId>
-              <artifactId>biz.aQute.bndlib</artifactId>
-              <version>${bnd.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
 
         <!-- Antrun here only to override eclipse settings -->
@@ -952,13 +938,13 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.felix</groupId>
-        <artifactId>maven-bundle-plugin</artifactId>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>bundle-manifest</id>
+            <id>bnd-process</id>
             <goals>
-              <goal>manifest</goal>
+              <goal>bnd-process</goal>
             </goals>
             <phase>process-classes</phase>
           </execution>
@@ -1399,7 +1385,7 @@
         <jdk>(,17)</jdk>
       </activation>
       <properties>
-        <bnd.version>6.4.1</bnd.version>
+        <bnd.plugin>6.4.1</bnd.plugin>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
on bnd-maven-plugin, it does not provide 'Include-Resource' and the 'Tool' goes unlisted.  I tried to make that show up and can get the NOTICE/LICENSE but not any properties as I see used on many now.  However those point local to the project so not sure how valuable they were to start with.