### PR TITLE
New property to add arguments for maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,6 +371,10 @@
     <!-- Excluded groups are ran on github ci, to force here, pass -D"excludedGroups=" -->
     <excludedGroups />
 
+    <!-- Arguments passed to the release preparation build. -->
+    <!-- To skip modernizer, for example, pass -DreleaseArgs="-Dmodernizer.skip=true". -->
+    <releaseArgs />
+
     <!-- Hack for single site builds so site:staging works as expected. Do not use with multi module!
          Instead adjust for fact that maven bug causes staging to be up one directory with 'reponame.git' -->
     <topSiteURL>${project.distributionManagement.site.url}</topSiteURL>
@@ -740,7 +744,7 @@
           <artifactId>maven-release-plugin</artifactId>
           <version>${release.plugin}</version>
           <configuration>
-            <arguments>-Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5</arguments>
+            <arguments>-Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 ${releaseArgs}</arguments>
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <releaseProfiles>release</releaseProfiles>


### PR DESCRIPTION
Hi @hazendaz ,

As you may be aware, on every release, there are some plugin errors that block the release process.
I think this allows us to workaround those errors by skipping plugin when necessary.
As I don't know how to test this locally, I am not 100% sure if this works.

FYI, the latest problem is caused by the modernizer.

> Failed to execute goal org.gaul:modernizer-maven-plugin:3.4.0:modernizer (modernizer) on project mybatis: Found 22 violations

It seems a little bit strange that these modernizer rules are enforced only when releasing a new version.

